### PR TITLE
Windows fixes

### DIFF
--- a/preferences.py
+++ b/preferences.py
@@ -13,7 +13,7 @@ class BrignetPrefs(bpy.types.AddonPreferences):
         if not os.path.isdir(env_path):
             return False
 
-        lib_path = os.path.join(env_path, 'lib')
+        lib_path = os.path.join(env_path, 'Lib')
         sitepackages = os.path.join(lib_path, 'site-packages')
 
         if not os.path.isdir(sitepackages):

--- a/rignetconnect.py
+++ b/rignetconnect.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import subprocess
 
 import trimesh
 import numpy as np
@@ -132,7 +133,7 @@ def create_single_data(mesh_obj):
         clear()
         raise FileNotFoundError("binvox executable not found in {0}, please check RigNet path in the addon preferences")
 
-    os.system(binvox_exe + " -d 88 " + fo_normalized.name)
+    subprocess.call([binvox_exe, "-d", "88", fo_normalized.name])
     with open(os.path.splitext(fo_normalized.name)[0] + '.binvox', 'rb') as fvox:
         vox = binvox_rw.read_as_3d_array(fvox)
 


### PR DESCRIPTION
Hey,

I found two issues when running brignet on Windows.

- My path appendation wasn't working due to a small spelling error
- My binvox process returned right after being called via `os.system` instead of running its task

